### PR TITLE
chore: market proxy API updates

### DIFF
--- a/examples/listen_and_respond_to_rfqs.py
+++ b/examples/listen_and_respond_to_rfqs.py
@@ -109,7 +109,7 @@ async def handle_order_added_message(message: server.ServerMessage, client: ws_c
         "Order added message handled\n%s [%s]", message.type().name, body)
 
     # Check if indicative order
-    if (body["market_id"] == "255"):
+    if (body["market_id"] == "none"):
         logging.info("RFQ received for %s %s", body["symbol"], body["side"])
 
         logging.info("Strategy detected: %s",

--- a/examples/query_positions.py
+++ b/examples/query_positions.py
@@ -6,5 +6,5 @@ from utils.access_token import generate_access_token
 def query_positions(cfg):
     token = generate_access_token(cfg["api_key"], cfg["private_key"])
     headers = {'credentials_secret': token}
-    r = requests.get(cfg["http_url"] + "/v1/api/positionInfo", headers=headers)
+    r = requests.get(cfg["http_url"] + "/v1/api/positions", headers=headers)
     print(r.text)

--- a/proxy_clients/ws.py
+++ b/proxy_clients/ws.py
@@ -56,7 +56,7 @@ class ProxyWSClient:
                 # Number of 10 min exchange cycles, the order will be active for
                 # "recv_window": "1" -> valid for 10 minutes
                 # "recv_window": "2" -> valid for 20 minutes etc ...
-                "recv_window": "1",
+                "recv_window": "4",
                 # Current UTC timestamp
                 "timestamp": str(utils.time.time_us()),
                 # Array of legs in {"sym": "BTC-20220902-17000P", "ratio": "1"} format


### PR DESCRIPTION
- change `market_id` to `none` for RFQs
- `v1/api/positionInfo` -> `v1/api/positions`
- RFQ duration to 30min ~ 4 cycles